### PR TITLE
replace `ord_subset` with `ordered-float`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 
 [dependencies]
 faer = { version = "0.21.2", default-features = false }
-ord_subset = "3.1.1"
+ordered-float = "5.0.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/cheb.rs
+++ b/src/cheb.rs
@@ -9,7 +9,7 @@
 //! [CPR Paper]: https://epubs.siam.org/doi/pdf/10.1137/110838297
 //! [chebfun]: https://github.com/chebfun/chebfun
 
-use ord_subset::{OrdSubsetIterExt, OrdSubsetSliceExt};
+use ordered_float::OrderedFloat;
 use std::f64::consts::PI;
 
 use faer::{Col, Mat, Row};
@@ -58,7 +58,11 @@ where
   // println!("{n} {}", c.len());
 
   // Find the last coefficient greater than tol, and truncate everything after it
-  let max_val = c.iter().map(|&x| x.abs()).ord_subset_max().unwrap();
+  let max_val = c
+    .iter()
+    .map(|&x| x.abs())
+    .max_by_key(|&v| OrderedFloat(v))
+    .unwrap();
   let tol = (1e-14 * max_val).max(f64::EPSILON);
 
   // Truncate all coefficients after trunc_i
@@ -162,7 +166,7 @@ impl Cheb {
       .map(|x| self.function_space(x))
       .collect();
 
-    roots.ord_subset_sort_unstable();
+    roots.sort_unstable_by_key(|&v| OrderedFloat(v));
     roots
   }
 

--- a/src/min.rs
+++ b/src/min.rs
@@ -1,6 +1,6 @@
 //! Methods to determine the minimum of a given function within a given range or bracket.
 
-use ord_subset::OrdSubsetIterExt;
+use ordered_float::OrderedFloat;
 
 use crate::compute_epsilon;
 
@@ -15,7 +15,7 @@ where
       let x = a + i as f64 * step;
       (x, f(x))
     })
-    .ord_subset_min_by_key(|&(_, fx)| fx)
+    .min_by_key(|&(_, fx)| OrderedFloat(fx))
     .unwrap()
 }
 

--- a/tests/test_cheb.rs
+++ b/tests/test_cheb.rs
@@ -1,8 +1,8 @@
 use approx::{assert_abs_diff_eq, assert_relative_eq};
 use fastrand::Rng;
 use itertools::{izip, Itertools};
-use ord_subset::OrdSubsetSliceExt;
 
+use ordered_float::OrderedFloat;
 use uniarity::cheb::Cheb;
 
 const N_TESTS: usize = 1_000;
@@ -17,7 +17,7 @@ fn test_small_polynomials() {
     let n_roots = rng.usize(1..=10);
 
     let mut known_roots: Vec<_> = (0..n_roots).map(|_| a + (b - a) * rng.f64()).collect();
-    known_roots.ord_subset_sort();
+    known_roots.sort_by_key(|&v| OrderedFloat(v));
 
     if known_roots.iter().tuple_windows().any(|(a, b)| b - a < 0.1) {
       continue;


### PR DESCRIPTION
`ord_subset` looks unmaintained and no longer builds on the latest Rust nightly.